### PR TITLE
Fix broken README

### DIFF
--- a/README.rst
+++ b/README.rst
@@ -50,7 +50,7 @@ or install it from repo:
 
 .. code-block:: bash
 
-    $ pip install https://github.com/api-ai/api-ai-python.git
+    $ pip install git+https://github.com/dialogflow/dialogflow-python-client.git
 
 You might run into problems because some dependencies in your python environment are missing. You need to install numpy (which is available in almost all package managers). For running the examples you also need python audio.
 

--- a/README.rst
+++ b/README.rst
@@ -67,12 +67,12 @@ Documentation
 Documentation is available at http://api.ai.
 
 ## How to make contributions?
-Please read and follow the steps in the [CONTRIBUTING.md](CONTRIBUTING.md).
+Please read and follow the steps in the `CONTRIBUTING <https://github.com/dialogflow/dialogflow-python-client/blob/master/CONTRIBUTING.md>`_.
 
 ## License
-See [LICENSE](LICENSE).
+See `LICENSE <https://github.com/dialogflow/dialogflow-python-client/blob/master/LICENSE>`_.
 
 ## Terms
-Your use of this sample is subject to, and by using or downloading the sample files you agree to comply with, the [Google APIs Terms of Service](https://developers.google.com/terms/).
+Your use of this sample is subject to, and by using or downloading the sample files you agree to comply with, the `Google APIs Terms of Service <https://developers.google.com/terms/>`_.
 
 This is not an official Google product.

--- a/README.rst
+++ b/README.rst
@@ -1,5 +1,5 @@
 api.ai: Python SDK for `API.AI <http://api.ai>`_
-=========================
+================================================
 
 .. image:: https://badge.fury.io/py/apiai.svg
     :target: http://badge.fury.io/py/apiai
@@ -14,13 +14,13 @@ Overview
 The API.AI Python SDK makes it easy to integrate speech recognition with API.AI natural language processing API. API.AI allows using voice commands and integration with dialog scenarios defined for a particular agent in API.AI.
 
 Prerequsites
---------
+------------
 
 Create an `API.AI account <http://api.ai>`_.
 
 
 Running examples
---------
+----------------
 
 1. Find examples from 'examples' path.
 2. Insert API key.

--- a/README.rst
+++ b/README.rst
@@ -4,8 +4,8 @@ api.ai: Python SDK for `API.AI <http://api.ai>`_
 .. image:: https://badge.fury.io/py/apiai.svg
     :target: http://badge.fury.io/py/apiai
 
-.. image:: https://travis-ci.org/api-ai/api-ai-python.svg
-    :target: https://travis-ci.org/api-ai/api-ai-python
+.. image:: https://travis-ci.org/dialogflow/dialogflow-python-client.svg
+    :target: https://travis-ci.org/dialogflow/dialogflow-python-client
 
 
 Overview


### PR DESCRIPTION
1. README was written in rst format but had .md extension.
2. Fixed some problems with rst format.
3. Updated documentation section urls (License, contributing).
4. Updated direct install using pip and repository url.
5. Fixed Travis url.

If you try to install directly from the repository pip will not be able to install since the repository url must be prefixed with `git+`

even when you fix this installation will fail with this message. (look at this [line](https://github.com/dialogflow/dialogflow-python-client/blob/master/setup.py#L51) this is the problem we don't have a README.rst file)
`IOError: [Errno 2] No such file or directory: 'README.rst'`

Travis url is linking for the old repository [(build status unknown)](https://api.travis-ci.org/api-ai/api-ai-python.svg).
